### PR TITLE
Printing full localhost URL when the server starts

### DIFF
--- a/app/japanese.go
+++ b/app/japanese.go
@@ -131,7 +131,7 @@ func main() {
 	router.HandleFunc("/update_word", UpdateWordEndpoint).Methods("POST")
 	router.PathPrefix("/").Handler(http.FileServer(http.Dir("../static")))
 
-	log.Printf("Listening on http://localhost:%s", port)
+	log.Printf("Running on http://localhost:%s", port)
 	if err := http.ListenAndServe(":"+port, router); err != nil {
 		log.Fatal(err)
 	}

--- a/app/japanese.go
+++ b/app/japanese.go
@@ -131,7 +131,7 @@ func main() {
 	router.HandleFunc("/update_word", UpdateWordEndpoint).Methods("POST")
 	router.PathPrefix("/").Handler(http.FileServer(http.Dir("../static")))
 
-	log.Printf("Listening on port %s", port)
+	log.Printf("Listening on http://localhost:%s", port)
 	if err := http.ListenAndServe(":"+port, router); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
When running the app the server will print the full localhost URL instead of just the port number. The advantage is that the user can right click on the link and open it in the browser directly instead of having to manually open the browser and typing the URL.

Before it was like this (non clickable):
![1](https://github.com/BrianWill/japanese_vocab/assets/76563803/8a04e1b6-087d-4d1b-9eef-ad7101b9dc09)


Now with this change it would display like this (I just right clicked on the URL):
![2](https://github.com/BrianWill/japanese_vocab/assets/76563803/f0795a33-7e0c-4272-ada0-497b6e8772a3)
